### PR TITLE
feat: require authentication sitewide

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,8 @@ gem "multi_xml", "~> 0.7.1"
 # User authentication
 gem "devise", "~> 4.9"
 
+gem "mutex_m"
+
 # Sentry dependencies
 gem "stackprof"
 gem "sentry-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
     msgpack (1.7.5)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
+    mutex_m (0.2.0)
     net-http (0.5.0)
       uri
     net-imap (0.5.1)
@@ -468,6 +469,7 @@ DEPENDENCIES
   kamal
   lograge (~> 0.14.0)
   multi_xml (~> 0.7.1)
+  mutex_m
   ox (~> 2.14)
   pg (~> 1.1)
   propshaft

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
+
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   get "pages/index"
+
+  devise_for :users
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -3,8 +3,22 @@
 require "test_helper"
 
 class PagesControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
+  test "should be redirected to log in page" do
     get pages_index_url
-    assert_response :success
+    assert_redirected_to new_user_session_path
+  end
+
+  class AuthenticatedUserTest < ActionDispatch::IntegrationTest
+    setup do
+      # TODO: follow up when the fix for the hack below is released https://github.com/heartcombo/devise/pull/5728
+      Rails.application.reload_routes_unless_loaded
+      @user = FactoryBot.create(:user)
+      sign_in @user
+    end
+
+    test "should get index" do
+      get pages_index_url
+      assert :success
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,5 +13,8 @@ module ActiveSupport
     fixtures :all
 
     # Add more helper methods to be used by all tests here...
+    include FactoryBot::Syntax::Methods
+    include Devise::Test::IntegrationHelpers
+    include Warden::Test::Helpers
   end
 end


### PR DESCRIPTION
There is a Devise fix for an issue regarding lazy loaded routes that hasn't yet been released: https://github.com/heartcombo/devise/pull/5728